### PR TITLE
Extract out websocket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Here is a code example:
 
 ```py
 import asyncio
+from websockets import connect
 from y_websocket import YDoc, WebsocketProvider
 
 async def main():
     ydoc = YDoc()
-    WebsocketProvider("ws://localhost:1234", "my-roomname", ydoc)
+    websocket = await connect("ws://localhost:1234")
+    WebsocketProvider(ydoc, websocket)
     ymap = ydoc.get_map("map")
     with ydoc.begin_transaction() as t:
         ymap.set(t, "key", "value")
@@ -24,9 +26,6 @@ async def main():
 asyncio.run(main())
 ```
 
-Note that although there is no `await` in `main()`, a `WebsocketProvider` instance has to run
-inside an event loop because it creates `asyncio` tasks.
-
-Also, `YDoc` has to be imported from `y_websocket` instead of `y_py`. This will change in the
+Note that `YDoc` has to be imported from `y_websocket` instead of `y_py`. This will change in the
 future, when `y_py` has the necessary event handlers. `y_websocket.YDoc` is a subclass of
 `y_py.YDoc`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ packages = find:
 python_requires = >=3.7
 
 install_requires =
-  websockets >=10.0
   y-py >=0.4.3
 
 [options.extras_require]
@@ -30,6 +29,7 @@ test =
   black
   pytest
   pytest-asyncio
+  websockets >=10.0
 
 [flake8]
 max-line-length = 100

--- a/tests/test_ypy_yjs.py
+++ b/tests/test_ypy_yjs.py
@@ -1,13 +1,15 @@
 import asyncio
 
 import pytest
+from websockets import connect  # type: ignore
 from y_websocket import YDoc, WebsocketProvider
 
 
 @pytest.mark.asyncio
 async def test_ypy_yjs(echo_server, yjs_client):
     ydoc = YDoc()
-    WebsocketProvider("ws://localhost:1234", "my-roomname", ydoc)
+    websocket = await connect("ws://localhost:1234")
+    WebsocketProvider(ydoc, websocket)
     ymap = ydoc.get_map("map")
     # set a value in "in"
     for v_in in ["0", "1"]:


### PR DESCRIPTION
The websocket is now passed as a parameter in order for `WebsocketProvider` to be agnostic to the websocket library. The websocket API should be similar to [websockets](https://github.com/aaugustin/websockets), in particular we need the following methods:
- `await websocket.send(message)`
- `async for message in websocket:`